### PR TITLE
会員の退会ステータスの表示を修正

### DIFF
--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -21,7 +21,7 @@
     <td><%= customer.email %></td>
     <td>
       <% if customer.delete_status? %>
-        無効
+        退会
       <% else %>
         有効
       <% end %>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -37,7 +37,7 @@
     <th>会員ステータス</th>
     <td>
       <% if @customer.delete_status? %>
-        無効
+        退会
       <% else %>
         有効
       <% end %>


### PR DESCRIPTION
管理者側で、会員一覧ページ・会員詳細ページの会員ステータス表示を「無効」から「退会」に修正。